### PR TITLE
CancellationToken support

### DIFF
--- a/src/InterpolatedSql.Dapper/IDapperSqlBuilderExtensions.cs
+++ b/src/InterpolatedSql.Dapper/IDapperSqlBuilderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Threading;
 using System.Threading.Tasks;
 using Dapper;
 using InterpolatedSql.Dapper.SqlBuilders;
@@ -8,7 +9,7 @@ using InterpolatedSql.Dapper.SqlBuilders;
 namespace InterpolatedSql.Dapper
 {
     /// <summary>
-    /// IDapperSqlCommand are "commands ready to run" - this is where we extend those commands with Dapper facades
+    /// IDapperSqlBuilder are "statements ready to run" - this is where we extend the builders with Dapper facades
     /// <see cref="InterpolatedSql.Dapper.SqlBuilders.SqlBuilder"/> is the most generic builder - and is always ready to run.
     /// <see cref="InterpolatedSql.Dapper.SqlBuilders.QueryBuilder"/> is a builder with some helpers to build SELECT queries - and is always ready to run.
     /// <see cref="InterpolatedSql.Dapper.SqlBuilders.FluentQueryBuilder.FluentQueryBuilder"/> is a step-by-step fluent builder - it is ready to run only in some stages of the builder
@@ -16,7 +17,7 @@ namespace InterpolatedSql.Dapper
     public static partial class IDapperSqlBuilderExtensions
     {
 
-        #region Dapper (IDapperSqlCommand.Execute())
+        #region Dapper (IDapperSqlBuilder.Execute())
         /// <summary>
         /// Executes the query (using Dapper), returning the number of rows affected.
         /// </summary>
@@ -29,15 +30,15 @@ namespace InterpolatedSql.Dapper
         /// <summary>
         /// Executes the query (using Dapper), returning the number of rows affected.
         /// </summary>
-        public static Task<int> ExecuteAsync(this IDapperSqlBuilder builder, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<int> ExecuteAsync(this IDapperSqlBuilder builder, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
             var command = builder.Build();
-            return command.DbConnection.ExecuteAsync(sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.ExecuteAsync(new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
 
         #endregion
 
-        #region Dapper (IDapperSqlCommand.ExecuteScalar())
+        #region Dapper (IDapperSqlBuilder.ExecuteScalar())
         /// <summary>
         /// Executes the query (using Dapper), returning the first cell returned, as object.
         /// </summary>
@@ -59,24 +60,24 @@ namespace InterpolatedSql.Dapper
         /// <summary>
         /// Executes the query (using Dapper), returning the first cell returned, as T.
         /// </summary>
-        public static Task<T> ExecuteScalarAsync<T>(this IDapperSqlBuilder builder, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<T> ExecuteScalarAsync<T>(this IDapperSqlBuilder builder, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
             var command = builder.Build();
-            return command.DbConnection.ExecuteScalarAsync<T>(sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.ExecuteScalarAsync<T>(new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
 
         /// <summary>
         /// Executes the query (using Dapper), returning the first cell returned, as object.
         /// </summary>
-        public static Task<object> ExecuteScalarAsync(this IDapperSqlBuilder builder, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<object> ExecuteScalarAsync(this IDapperSqlBuilder builder, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
             var command = builder.Build();
-            return command.DbConnection.ExecuteScalarAsync(sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.ExecuteScalarAsync(new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
 
         #endregion
 
-        #region Dapper (IDapperSqlCommand.QueryMultiple())
+        #region Dapper (IDapperSqlBuilder.QueryMultiple())
         /// <summary>
         /// Executes the query (using Dapper), returning multiple result sets, and access each in turn.
         /// </summary>
@@ -90,16 +91,16 @@ namespace InterpolatedSql.Dapper
         /// <summary>
         /// Executes the query (using Dapper), returning multiple result sets, and access each in turn.
         /// </summary>
-        public static Task<SqlMapper.GridReader> QueryMultipleAsync(this IDapperSqlBuilder builder, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<SqlMapper.GridReader> QueryMultipleAsync(this IDapperSqlBuilder builder, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
             var command = builder.Build();
             // DynamicParameters because QueryMultiple with Stored Procedures doesn't work with Dictionary<string, object> - see https://github.com/DapperLib/Dapper/issues/1580#issuecomment-889813797
-            return command.DbConnection.QueryMultipleAsync(sql: command.Sql, param: ParametersDictionary.LoadFrom(command).DynamicParameters, transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.QueryMultipleAsync(new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command).DynamicParameters, transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
 
         #endregion
 
-        #region Dapper (IDapperSqlCommand.Query<T>)
+        #region Dapper (IDapperSqlBuilder.Query<T>)
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as T.
         /// </summary>
@@ -146,7 +147,7 @@ namespace InterpolatedSql.Dapper
         }
         #endregion
 
-        #region Dapper (IDapperSqlCommand.Query() dynamic)
+        #region Dapper (IDapperSqlBuilder.Query() dynamic)
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as dynamic objects.
         /// </summary>
@@ -193,7 +194,7 @@ namespace InterpolatedSql.Dapper
         }
         #endregion
 
-        #region Dapper (IDapperSqlCommand.Query<object>())
+        #region Dapper (IDapperSqlBuilder.Query<object>())
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as type.
         /// </summary>
@@ -240,142 +241,148 @@ namespace InterpolatedSql.Dapper
         }
         #endregion
 
-        #region Dapper (IDapperSqlCommand.QueryAsync<T>)
+        #region Dapper (IDapperSqlBuilder.QueryAsync<T>)
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as T.
         /// </summary>
-        public static Task<IEnumerable<T>> QueryAsync<T>(this IDapperSqlBuilder builder, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<IEnumerable<T>> QueryAsync<T>(this IDapperSqlBuilder builder, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
             var command = builder.Build();
-            return command.DbConnection.QueryAsync<T>(sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.QueryAsync<T>(new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
 
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as T.
         /// </summary>
-        public static Task<T> QueryFirstAsync<T>(this IDapperSqlBuilder builder, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<T> QueryFirstAsync<T>(this IDapperSqlBuilder builder, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
             var command = builder.Build();
-            return command.DbConnection.QueryFirstAsync<T>(sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.QueryFirstAsync<T>(new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
+
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as T.
         /// </summary>
-        public static Task<T> QueryFirstOrDefaultAsync<T>(this IDapperSqlBuilder builder, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<T> QueryFirstOrDefaultAsync<T>(this IDapperSqlBuilder builder, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
             var command = builder.Build();
-            return command.DbConnection.QueryFirstOrDefaultAsync<T>(sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.QueryFirstOrDefaultAsync<T>(new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
+
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as T.
         /// </summary>
-        public static Task<T> QuerySingleAsync<T>(this IDapperSqlBuilder builder, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<T> QuerySingleAsync<T>(this IDapperSqlBuilder builder, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
             var command = builder.Build();
-            return command.DbConnection.QuerySingleAsync<T>(sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.QuerySingleAsync<T>(new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
+
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as T.
         /// </summary>
-        public static Task<T> QuerySingleOrDefaultAsync<T>(this IDapperSqlBuilder builder, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<T> QuerySingleOrDefaultAsync<T>(this IDapperSqlBuilder builder, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
             var command = builder.Build();
-            return command.DbConnection.QuerySingleOrDefaultAsync<T>(sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.QuerySingleOrDefaultAsync<T>(new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
         #endregion
 
-        #region Dapper (IDapperSqlCommand.QueryAsync() dynamic)
+        #region Dapper (IDapperSqlBuilder.QueryAsync() dynamic)
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as dynamic objects.
         /// </summary>
-        public static Task<IEnumerable<dynamic>> QueryAsync(this IDapperSqlBuilder builder, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<IEnumerable<dynamic>> QueryAsync(this IDapperSqlBuilder builder, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
             var command = builder.Build();
-            return command.DbConnection.QueryAsync(sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.QueryAsync(new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
 
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as dynamic objects.
         /// </summary>
-        public static Task<dynamic> QueryFirstAsync(this IDapperSqlBuilder builder, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<dynamic> QueryFirstAsync(this IDapperSqlBuilder builder, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
             var command = builder.Build();
-            return command.DbConnection.QueryFirstAsync(sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.QueryFirstAsync(new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
 
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as dynamic objects.
         /// </summary>
-        public static Task<dynamic> QueryFirstOrDefaultAsync(this IDapperSqlBuilder builder, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<dynamic> QueryFirstOrDefaultAsync(this IDapperSqlBuilder builder, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
             var command = builder.Build();
-            return command.DbConnection.QueryFirstOrDefaultAsync(sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.QueryFirstOrDefaultAsync(new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
 
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as dynamic objects.
         /// </summary>
-        public static Task<dynamic> QuerySingleAsync(this IDapperSqlBuilder builder, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<dynamic> QuerySingleAsync(this IDapperSqlBuilder builder, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
             var command = builder.Build();
-            return command.DbConnection.QuerySingleAsync(sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.QuerySingleAsync(new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
 
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as dynamic objects.
         /// </summary>
-        public static Task<dynamic> QuerySingleOrDefaultAsync(this IDapperSqlBuilder builder, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<dynamic> QuerySingleOrDefaultAsync(this IDapperSqlBuilder builder, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
             var command = builder.Build();
-            return command.DbConnection.QuerySingleOrDefaultAsync(sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.QuerySingleOrDefaultAsync(new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
         #endregion
 
-        #region Dapper (IDapperSqlCommand.QueryAsync<object>)
+        #region Dapper (IDapperSqlBuilder.QueryAsync<object>)
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as type.
         /// </summary>
-        public static Task<IEnumerable<object>> QueryAsync(this IDapperSqlBuilder builder, Type type, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<IEnumerable<object>> QueryAsync(this IDapperSqlBuilder builder, Type type, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
             var command = builder.Build();
-            return command.DbConnection.QueryAsync(type: type, sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.QueryAsync(type: type, command: new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
 
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as type.
         /// </summary>
-        public static Task<object> QueryFirstAsync(this IDapperSqlBuilder builder, Type type, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<object> QueryFirstAsync(this IDapperSqlBuilder builder, Type type, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
             var command = builder.Build();
-            return command.DbConnection.QueryFirstAsync(type: type, sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.QueryFirstAsync(type: type, command: new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
+
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as type.
         /// </summary>
-        public static Task<object> QueryFirstOrDefaultAsync(this IDapperSqlBuilder builder, Type type, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<object> QueryFirstOrDefaultAsync(this IDapperSqlBuilder builder, Type type, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
             var command = builder.Build();
-            return command.DbConnection.QueryFirstOrDefaultAsync(type: type, sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.QueryFirstOrDefaultAsync(type: type, command: new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
+
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as type.
         /// </summary>
-        public static Task<object> QuerySingleAsync(this IDapperSqlBuilder builder, Type type, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<object> QuerySingleAsync(this IDapperSqlBuilder builder, Type type, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
             var command = builder.Build();
-            return command.DbConnection.QuerySingleAsync(type: type, sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.QuerySingleAsync(type: type, command: new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
+
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as type.
         /// </summary>
-        public static Task<object> QuerySingleOrDefaultAsync(this IDapperSqlBuilder builder, Type type, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<object> QuerySingleOrDefaultAsync(this IDapperSqlBuilder builder, Type type, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
             var command = builder.Build();
-            return command.DbConnection.QuerySingleOrDefaultAsync(type: type, sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.QuerySingleOrDefaultAsync(type: type, new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
         #endregion
 
-        #region Dapper (IDapperSqlCommand.ExecuteReader())
+        #region Dapper (IDapperSqlBuilder.ExecuteReader())
         /// <summary>
         /// Executes the query (using Dapper), returning an System.Data.IDataReader
         /// </summary>
@@ -388,10 +395,10 @@ namespace InterpolatedSql.Dapper
         /// <summary>
         /// Executes the query (using Dapper), returning an System.Data.IDataReader
         /// </summary>
-        public static Task<IDataReader> ExecuteReaderAsync(this IDapperSqlBuilder builder, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<IDataReader> ExecuteReaderAsync(this IDapperSqlBuilder builder, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
             var command = builder.Build();
-            return command.DbConnection.ExecuteReaderAsync(sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.ExecuteReaderAsync(new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
         #endregion
 
@@ -403,6 +410,7 @@ namespace InterpolatedSql.Dapper
         /// <typeparam name="TFirst">The first type in the recordset.</typeparam>
         /// <typeparam name="TSecond">The second type in the recordset.</typeparam>
         /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="builder">IDapperSqlBuilder used to query the DbConnection.</param>
         /// <param name="map">The function to map row types to the return type.</param>
         /// <param name="transaction">The transaction to use for this query.</param>
         /// <param name="buffered">Whether to buffer the results in memory.</param>
@@ -410,12 +418,11 @@ namespace InterpolatedSql.Dapper
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static IEnumerable<TReturn> Query<TFirst, TSecond, TReturn>(this IDapperSqlBuilder builder, Func<TFirst, TSecond, TReturn> map, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
+        public static IEnumerable<TReturn> Query<TFirst, TSecond, TReturn>(this IDapperSqlBuilder builder, Func<TFirst, TSecond, TReturn> map, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
         {
             var command = builder.Build();
             return command.DbConnection.Query<TFirst, TSecond, TReturn>(sql: command.Sql, map: map, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, buffered: buffered, splitOn: splitOn);
         }
-
 
         /// <summary>
         /// Perform a multi-mapping query with 3 input types.
@@ -425,6 +432,7 @@ namespace InterpolatedSql.Dapper
         /// <typeparam name="TSecond">The second type in the recordset.</typeparam>
         /// <typeparam name="TThird">The third type in the recordset.</typeparam>
         /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="builder">IDapperSqlBuilder used to query the DbConnection.</param>
         /// <param name="map">The function to map row types to the return type.</param>
         /// <param name="transaction">The transaction to use for this query.</param>
         /// <param name="buffered">Whether to buffer the results in memory.</param>
@@ -432,7 +440,7 @@ namespace InterpolatedSql.Dapper
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static IEnumerable<TReturn> Query<TFirst, TSecond, TThird, TReturn>(this IDapperSqlBuilder builder, Func<TFirst, TSecond, TThird, TReturn> map, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
+        public static IEnumerable<TReturn> Query<TFirst, TSecond, TThird, TReturn>(this IDapperSqlBuilder builder, Func<TFirst, TSecond, TThird, TReturn> map, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
         {
             var command = builder.Build();
             return command.DbConnection.Query<TFirst, TSecond, TThird, TReturn>(sql: command.Sql, map: map, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, buffered: buffered, splitOn: splitOn);
@@ -447,6 +455,7 @@ namespace InterpolatedSql.Dapper
         /// <typeparam name="TThird">The third type in the recordset.</typeparam>
         /// <typeparam name="TFourth">The fourth type in the recordset.</typeparam>
         /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="builder">IDapperSqlBuilder used to query the DbConnection.</param>
         /// <param name="map">The function to map row types to the return type.</param>
         /// <param name="transaction">The transaction to use for this query.</param>
         /// <param name="buffered">Whether to buffer the results in memory.</param>
@@ -454,7 +463,7 @@ namespace InterpolatedSql.Dapper
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static IEnumerable<TReturn> Query<TFirst, TSecond, TThird, TFourth, TReturn>(this IDapperSqlBuilder builder, Func<TFirst, TSecond, TThird, TFourth, TReturn> map, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
+        public static IEnumerable<TReturn> Query<TFirst, TSecond, TThird, TFourth, TReturn>(this IDapperSqlBuilder builder, Func<TFirst, TSecond, TThird, TFourth, TReturn> map, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
         {
             var command = builder.Build();
             return command.DbConnection.Query<TFirst, TSecond, TThird, TFourth, TReturn>(sql: command.Sql, map: map, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, buffered: buffered, splitOn: splitOn);
@@ -470,6 +479,7 @@ namespace InterpolatedSql.Dapper
         /// <typeparam name="TFourth">The fourth type in the recordset.</typeparam>
         /// <typeparam name="TFifth">The fifth type in the recordset.</typeparam>
         /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="builder">IDapperSqlBuilder used to query the DbConnection.</param>
         /// <param name="map">The function to map row types to the return type.</param>
         /// <param name="transaction">The transaction to use for this query.</param>
         /// <param name="buffered">Whether to buffer the results in memory.</param>
@@ -477,7 +487,7 @@ namespace InterpolatedSql.Dapper
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static IEnumerable<TReturn> Query<TFirst, TSecond, TThird, TFourth, TFifth, TReturn>(this IDapperSqlBuilder builder, Func<TFirst, TSecond, TThird, TFourth, TFifth, TReturn> map, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
+        public static IEnumerable<TReturn> Query<TFirst, TSecond, TThird, TFourth, TFifth, TReturn>(this IDapperSqlBuilder builder, Func<TFirst, TSecond, TThird, TFourth, TFifth, TReturn> map, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
         {
             var command = builder.Build();
             return command.DbConnection.Query<TFirst, TSecond, TThird, TFourth, TFifth, TReturn>(sql: command.Sql, map: map, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, buffered: buffered, splitOn: splitOn);
@@ -494,6 +504,7 @@ namespace InterpolatedSql.Dapper
         /// <typeparam name="TFifth">The fifth type in the recordset.</typeparam>
         /// <typeparam name="TSixth">The sixth type in the recordset.</typeparam>
         /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="builder">IDapperSqlBuilder used to query the DbConnection.</param>
         /// <param name="map">The function to map row types to the return type.</param>
         /// <param name="transaction">The transaction to use for this query.</param>
         /// <param name="buffered">Whether to buffer the results in memory.</param>
@@ -501,7 +512,7 @@ namespace InterpolatedSql.Dapper
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static IEnumerable<TReturn> Query<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn>(this IDapperSqlBuilder builder, Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn> map, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
+        public static IEnumerable<TReturn> Query<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn>(this IDapperSqlBuilder builder, Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn> map, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
         {
             var command = builder.Build();
             return command.DbConnection.Query<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn>(sql: command.Sql, map: map, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, buffered: buffered, splitOn: splitOn);
@@ -519,6 +530,7 @@ namespace InterpolatedSql.Dapper
         /// <typeparam name="TSixth">The sixth type in the recordset.</typeparam>
         /// <typeparam name="TSeventh">The seventh type in the recordset.</typeparam>
         /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="builder">IDapperSqlBuilder used to query the DbConnection.</param>
         /// <param name="map">The function to map row types to the return type.</param>
         /// <param name="transaction">The transaction to use for this query.</param>
         /// <param name="buffered">Whether to buffer the results in memory.</param>
@@ -526,7 +538,7 @@ namespace InterpolatedSql.Dapper
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static IEnumerable<TReturn> Query<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(this IDapperSqlBuilder builder, Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn> map, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
+        public static IEnumerable<TReturn> Query<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(this IDapperSqlBuilder builder, Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn> map, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
         {
             var command = builder.Build();
             return command.DbConnection.Query<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(sql: command.Sql, map: map, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, buffered: buffered, splitOn: splitOn);
@@ -537,6 +549,7 @@ namespace InterpolatedSql.Dapper
         /// This returns a single type, combined from the raw types via <paramref name="map"/>.
         /// </summary>
         /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="builder">IDapperSqlBuilder used to query the DbConnection.</param>
         /// <param name="types">Array of types in the recordset.</param>
         /// <param name="map">The function to map row types to the return type.</param>
         /// <param name="transaction">The transaction to use for this query.</param>
@@ -545,7 +558,7 @@ namespace InterpolatedSql.Dapper
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static IEnumerable<TReturn> Query<TReturn>(this IDapperSqlBuilder builder, Type[] types, Func<object[], TReturn> map, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
+        public static IEnumerable<TReturn> Query<TReturn>(this IDapperSqlBuilder builder, Type[] types, Func<object[], TReturn> map, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
         {
             var command = builder.Build();
             return command.DbConnection.Query<TReturn>(sql: command.Sql, types, map: map, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, buffered: buffered, splitOn: splitOn);
@@ -561,17 +574,19 @@ namespace InterpolatedSql.Dapper
         /// <typeparam name="TFirst">The first type in the recordset.</typeparam>
         /// <typeparam name="TSecond">The second type in the recordset.</typeparam>
         /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="builder">IDapperSqlBuilder used to query the DbConnection.</param>
         /// <param name="map">The function to map row types to the return type.</param>
         /// <param name="transaction">The transaction to use for this query.</param>
         /// <param name="buffered">Whether to buffer the results in memory.</param>
         /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
+        /// <param name="cancellationToken">The cancellation token for this command.</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TReturn>(this IDapperSqlBuilder builder, Func<TFirst, TSecond, TReturn> map, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TReturn>(this IDapperSqlBuilder builder, Func<TFirst, TSecond, TReturn> map, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
             var command = builder.Build();
-            return command.DbConnection.QueryAsync<TFirst, TSecond, TReturn>(sql: command.Sql, map: map, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, buffered: buffered, splitOn: splitOn);
+            return command.DbConnection.QueryAsync(map: map, splitOn: splitOn, command: new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, flags: buffered ? CommandFlags.Buffered : CommandFlags.None, cancellationToken: cancellationToken));
         }
 
 
@@ -583,17 +598,19 @@ namespace InterpolatedSql.Dapper
         /// <typeparam name="TSecond">The second type in the recordset.</typeparam>
         /// <typeparam name="TThird">The third type in the recordset.</typeparam>
         /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="builder">IDapperSqlBuilder used to query the DbConnection.</param>
         /// <param name="map">The function to map row types to the return type.</param>
         /// <param name="transaction">The transaction to use for this query.</param>
         /// <param name="buffered">Whether to buffer the results in memory.</param>
         /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
+        /// <param name="cancellationToken">The cancellation token for this command.</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TReturn>(this IDapperSqlBuilder builder, Func<TFirst, TSecond, TThird, TReturn> map, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TReturn>(this IDapperSqlBuilder builder, Func<TFirst, TSecond, TThird, TReturn> map, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
             var command = builder.Build();
-            return command.DbConnection.QueryAsync<TFirst, TSecond, TThird, TReturn>(sql: command.Sql, map: map, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, buffered: buffered, splitOn: splitOn);
+            return command.DbConnection.QueryAsync(map: map, splitOn: splitOn, command: new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, flags: buffered ? CommandFlags.Buffered : CommandFlags.None, cancellationToken: cancellationToken));
         }
 
         /// <summary>
@@ -605,17 +622,19 @@ namespace InterpolatedSql.Dapper
         /// <typeparam name="TThird">The third type in the recordset.</typeparam>
         /// <typeparam name="TFourth">The fourth type in the recordset.</typeparam>
         /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="builder">IDapperSqlBuilder used to query the DbConnection.</param>
         /// <param name="map">The function to map row types to the return type.</param>
         /// <param name="transaction">The transaction to use for this query.</param>
         /// <param name="buffered">Whether to buffer the results in memory.</param>
         /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
+        /// <param name="cancellationToken">The cancellation token for this command.</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TFourth, TReturn>(this IDapperSqlBuilder builder, Func<TFirst, TSecond, TThird, TFourth, TReturn> map, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TFourth, TReturn>(this IDapperSqlBuilder builder, Func<TFirst, TSecond, TThird, TFourth, TReturn> map, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
             var command = builder.Build();
-            return command.DbConnection.QueryAsync<TFirst, TSecond, TThird, TFourth, TReturn>(sql: command.Sql, map: map, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, buffered: buffered, splitOn: splitOn);
+            return command.DbConnection.QueryAsync(map: map, splitOn: splitOn, command: new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, flags: buffered ? CommandFlags.Buffered : CommandFlags.None, cancellationToken: cancellationToken));
         }
 
         /// <summary>
@@ -628,17 +647,19 @@ namespace InterpolatedSql.Dapper
         /// <typeparam name="TFourth">The fourth type in the recordset.</typeparam>
         /// <typeparam name="TFifth">The fifth type in the recordset.</typeparam>
         /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="builder">IDapperSqlBuilder used to query the DbConnection.</param>
         /// <param name="map">The function to map row types to the return type.</param>
         /// <param name="transaction">The transaction to use for this query.</param>
         /// <param name="buffered">Whether to buffer the results in memory.</param>
         /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
+        /// <param name="cancellationToken">The cancellation token for this command.</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TReturn>(this IDapperSqlBuilder builder, Func<TFirst, TSecond, TThird, TFourth, TFifth, TReturn> map, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TReturn>(this IDapperSqlBuilder builder, Func<TFirst, TSecond, TThird, TFourth, TFifth, TReturn> map, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
             var command = builder.Build();
-            return command.DbConnection.QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TReturn>(sql: command.Sql, map: map, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, buffered: buffered, splitOn: splitOn);
+            return command.DbConnection.QueryAsync(map: map, splitOn: splitOn, command: new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, flags: buffered ? CommandFlags.Buffered : CommandFlags.None, cancellationToken: cancellationToken));
         }
 
         /// <summary>
@@ -652,17 +673,19 @@ namespace InterpolatedSql.Dapper
         /// <typeparam name="TFifth">The fifth type in the recordset.</typeparam>
         /// <typeparam name="TSixth">The sixth type in the recordset.</typeparam>
         /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="builder">IDapperSqlBuilder used to query the DbConnection.</param>
         /// <param name="map">The function to map row types to the return type.</param>
         /// <param name="transaction">The transaction to use for this query.</param>
         /// <param name="buffered">Whether to buffer the results in memory.</param>
         /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
+        /// <param name="cancellationToken">The cancellation token for this command.</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn>(this IDapperSqlBuilder builder, Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn> map, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn>(this IDapperSqlBuilder builder, Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn> map, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
             var command = builder.Build();
-            return command.DbConnection.QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn>(sql: command.Sql, map: map, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, buffered: buffered, splitOn: splitOn);
+            return command.DbConnection.QueryAsync(map: map, splitOn: splitOn, command: new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, flags: buffered ? CommandFlags.Buffered : CommandFlags.None, cancellationToken: cancellationToken));
         }
 
         /// <summary>
@@ -677,17 +700,19 @@ namespace InterpolatedSql.Dapper
         /// <typeparam name="TSixth">The sixth type in the recordset.</typeparam>
         /// <typeparam name="TSeventh">The seventh type in the recordset.</typeparam>
         /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="builder">IDapperSqlBuilder used to query the DbConnection.</param>
         /// <param name="map">The function to map row types to the return type.</param>
         /// <param name="transaction">The transaction to use for this query.</param>
         /// <param name="buffered">Whether to buffer the results in memory.</param>
         /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
+        /// <param name="cancellationToken">The cancellation token for this command.</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(this IDapperSqlBuilder builder, Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn> map, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(this IDapperSqlBuilder builder, Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn> map, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
             var command = builder.Build();
-            return command.DbConnection.QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(sql: command.Sql, map: map, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, buffered: buffered, splitOn: splitOn);
+            return command.DbConnection.QueryAsync(map: map, splitOn: splitOn, command: new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, flags: buffered ? CommandFlags.Buffered : CommandFlags.None, cancellationToken: cancellationToken));
         }
 
         /// <summary>
@@ -695,6 +720,7 @@ namespace InterpolatedSql.Dapper
         /// This returns a single type, combined from the raw types via <paramref name="map"/>.
         /// </summary>
         /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="builder">IDapperSqlBuilder used to query the DbConnection.</param>
         /// <param name="types">Array of types in the recordset.</param>
         /// <param name="map">The function to map row types to the return type.</param>
         /// <param name="transaction">The transaction to use for this query.</param>
@@ -702,15 +728,15 @@ namespace InterpolatedSql.Dapper
         /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
+        /// <param name="cancellationToken">The cancellation token for this command.</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static Task<IEnumerable<TReturn>> QueryAsync<TReturn>(this IDapperSqlBuilder builder, Type[] types, Func<object[], TReturn> map, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<IEnumerable<TReturn>> QueryAsync<TReturn>(this IDapperSqlBuilder builder, Type[] types, Func<object[], TReturn> map, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
             var command = builder.Build();
-            return command.DbConnection.QueryAsync<TReturn>(sql: command.Sql, types, map: map, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, buffered: buffered, splitOn: splitOn);
+            // return command.DbConnection.QueryAsync(command: new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, flags: buffered ? CommandFlags.Buffered : CommandFlags.None, cancellationToken: cancellationToken), types: types, map: map, splitOn: splitOn);
+            return command.DbConnection.QueryAsync(sql: command.Sql, types, map: map, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, buffered: buffered, splitOn: splitOn);
         }
 
         #endregion
-
-
     }
 }

--- a/src/InterpolatedSql.Dapper/IDapperSqlCommandExtensions.cs
+++ b/src/InterpolatedSql.Dapper/IDapperSqlCommandExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Threading;
 using System.Threading.Tasks;
 using Dapper;
 
@@ -27,9 +28,9 @@ namespace InterpolatedSql.Dapper
         /// <summary>
         /// Executes the query (using Dapper), returning the number of rows affected.
         /// </summary>
-        public static Task<int> ExecuteAsync(this IDapperSqlCommand command, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<int> ExecuteAsync(this IDapperSqlCommand command, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
-            return command.DbConnection.ExecuteAsync(sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.ExecuteAsync(new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
 
         #endregion
@@ -46,25 +47,25 @@ namespace InterpolatedSql.Dapper
         /// <summary>
         /// Executes the query (using Dapper), returning the first cell returned, as T.
         /// </summary>
-        public static T ExecuteScalar<T>(this IDapperSqlCommand command, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static T ExecuteScalar<T>(this IDapperSqlCommand command, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
-            return command.DbConnection.ExecuteScalar<T>(sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.ExecuteScalar<T>(new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
 
         /// <summary>
         /// Executes the query (using Dapper), returning the first cell returned, as T.
         /// </summary>
-        public static Task<T> ExecuteScalarAsync<T>(this IDapperSqlCommand command, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<T> ExecuteScalarAsync<T>(this IDapperSqlCommand command, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
-            return command.DbConnection.ExecuteScalarAsync<T>(sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.ExecuteScalarAsync<T>(new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
 
         /// <summary>
         /// Executes the query (using Dapper), returning the first cell returned, as object.
         /// </summary>
-        public static Task<object> ExecuteScalarAsync(this IDapperSqlCommand command, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<object> ExecuteScalarAsync(this IDapperSqlCommand command, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
-            return command.DbConnection.ExecuteScalarAsync(sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.ExecuteScalarAsync(new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
 
         #endregion
@@ -82,10 +83,10 @@ namespace InterpolatedSql.Dapper
         /// <summary>
         /// Executes the query (using Dapper), returning multiple result sets, and access each in turn.
         /// </summary>
-        public static Task<SqlMapper.GridReader> QueryMultipleAsync(this IDapperSqlCommand command, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<SqlMapper.GridReader> QueryMultipleAsync(this IDapperSqlCommand command, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
             // DynamicParameters because QueryMultiple with Stored Procedures doesn't work with Dictionary<string, object> - see https://github.com/DapperLib/Dapper/issues/1580#issuecomment-889813797
-            return command.DbConnection.QueryMultipleAsync(sql: command.Sql, param: ParametersDictionary.LoadFrom(command).DynamicParameters, transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.QueryMultipleAsync(new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command).DynamicParameters, transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
 
         #endregion
@@ -220,38 +221,41 @@ namespace InterpolatedSql.Dapper
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as T.
         /// </summary>
-        public static Task<IEnumerable<T>> QueryAsync<T>(this IDapperSqlCommand command, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<IEnumerable<T>> QueryAsync<T>(this IDapperSqlCommand command, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
-            return command.DbConnection.QueryAsync<T>(sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.QueryAsync<T>(new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
 
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as T.
         /// </summary>
-        public static Task<T> QueryFirstAsync<T>(this IDapperSqlCommand command, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<T> QueryFirstAsync<T>(this IDapperSqlCommand command, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
-            return command.DbConnection.QueryFirstAsync<T>(sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.QueryFirstAsync<T>(new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
+
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as T.
         /// </summary>
-        public static Task<T> QueryFirstOrDefaultAsync<T>(this IDapperSqlCommand command, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<T> QueryFirstOrDefaultAsync<T>(this IDapperSqlCommand command, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
-            return command.DbConnection.QueryFirstOrDefaultAsync<T>(sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.QueryFirstOrDefaultAsync<T>(new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
+
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as T.
         /// </summary>
-        public static Task<T> QuerySingleAsync<T>(this IDapperSqlCommand command, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<T> QuerySingleAsync<T>(this IDapperSqlCommand command, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
-            return command.DbConnection.QuerySingleAsync<T>(sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.QuerySingleAsync<T>(new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
+
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as T.
         /// </summary>
-        public static Task<T> QuerySingleOrDefaultAsync<T>(this IDapperSqlCommand command, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<T> QuerySingleOrDefaultAsync<T>(this IDapperSqlCommand command, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
-            return command.DbConnection.QuerySingleOrDefaultAsync<T>(sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.QuerySingleOrDefaultAsync<T>(new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
         #endregion
 
@@ -259,41 +263,41 @@ namespace InterpolatedSql.Dapper
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as dynamic objects.
         /// </summary>
-        public static Task<IEnumerable<dynamic>> QueryAsync(this IDapperSqlCommand command, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<IEnumerable<dynamic>> QueryAsync(this IDapperSqlCommand command, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
-            return command.DbConnection.QueryAsync(sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.QueryAsync(new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
 
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as dynamic objects.
         /// </summary>
-        public static Task<dynamic> QueryFirstAsync(this IDapperSqlCommand command, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<dynamic> QueryFirstAsync(this IDapperSqlCommand command, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
-            return command.DbConnection.QueryFirstAsync(sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.QueryFirstAsync(new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
 
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as dynamic objects.
         /// </summary>
-        public static Task<dynamic> QueryFirstOrDefaultAsync(this IDapperSqlCommand command, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<dynamic> QueryFirstOrDefaultAsync(this IDapperSqlCommand command, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
-            return command.DbConnection.QueryFirstOrDefaultAsync(sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.QueryFirstOrDefaultAsync(new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
 
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as dynamic objects.
         /// </summary>
-        public static Task<dynamic> QuerySingleAsync(this IDapperSqlCommand command, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<dynamic> QuerySingleAsync(this IDapperSqlCommand command, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
-            return command.DbConnection.QuerySingleAsync(sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.QuerySingleAsync(new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
 
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as dynamic objects.
         /// </summary>
-        public static Task<dynamic> QuerySingleOrDefaultAsync(this IDapperSqlCommand command, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<dynamic> QuerySingleOrDefaultAsync(this IDapperSqlCommand command, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
-            return command.DbConnection.QuerySingleOrDefaultAsync(sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.QuerySingleOrDefaultAsync(new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
         #endregion
 
@@ -301,38 +305,41 @@ namespace InterpolatedSql.Dapper
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as type.
         /// </summary>
-        public static Task<IEnumerable<object>> QueryAsync(this IDapperSqlCommand command, Type type, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<IEnumerable<object>> QueryAsync(this IDapperSqlCommand command, Type type, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
-            return command.DbConnection.QueryAsync(type: type, sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.QueryAsync(type: type, command: new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
 
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as type.
         /// </summary>
-        public static Task<object> QueryFirstAsync(this IDapperSqlCommand command, Type type, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<object> QueryFirstAsync(this IDapperSqlCommand command, Type type, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
-            return command.DbConnection.QueryFirstAsync(type: type, sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.QueryFirstAsync(type: type, command: new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
+
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as type.
         /// </summary>
-        public static Task<object> QueryFirstOrDefaultAsync(this IDapperSqlCommand command, Type type, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<object> QueryFirstOrDefaultAsync(this IDapperSqlCommand command, Type type, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
-            return command.DbConnection.QueryFirstOrDefaultAsync(type: type, sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.QueryFirstOrDefaultAsync(type: type, command: new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
+
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as type.
         /// </summary>
-        public static Task<object> QuerySingleAsync(this IDapperSqlCommand command, Type type, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<object> QuerySingleAsync(this IDapperSqlCommand command, Type type, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
-            return command.DbConnection.QuerySingleAsync(type: type, sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.QuerySingleAsync(type: type, command: new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
+
         /// <summary>
         /// Executes the query (using Dapper), returning the data typed as type.
         /// </summary>
-        public static Task<object> QuerySingleOrDefaultAsync(this IDapperSqlCommand command, Type type, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<object> QuerySingleOrDefaultAsync(this IDapperSqlCommand command, Type type, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
-            return command.DbConnection.QuerySingleOrDefaultAsync(type: type, sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.QuerySingleOrDefaultAsync(type: type, command: new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
         #endregion
 
@@ -348,9 +355,9 @@ namespace InterpolatedSql.Dapper
         /// <summary>
         /// Executes the query (using Dapper), returning an System.Data.IDataReader
         /// </summary>
-        public static Task<IDataReader> ExecuteReaderAsync(this IDapperSqlCommand command, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<IDataReader> ExecuteReaderAsync(this IDapperSqlCommand command, IDbTransaction? transaction = null, int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
-            return command.DbConnection.ExecuteReaderAsync(sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType);
+            return command.DbConnection.ExecuteReaderAsync(new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, cancellationToken: cancellationToken));
         }
         #endregion
 
@@ -362,6 +369,7 @@ namespace InterpolatedSql.Dapper
         /// <typeparam name="TFirst">The first type in the recordset.</typeparam>
         /// <typeparam name="TSecond">The second type in the recordset.</typeparam>
         /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="command">IDapperSqlCommand used to query the DbConnection.</param>
         /// <param name="map">The function to map row types to the return type.</param>
         /// <param name="transaction">The transaction to use for this query.</param>
         /// <param name="buffered">Whether to buffer the results in memory.</param>
@@ -369,7 +377,7 @@ namespace InterpolatedSql.Dapper
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static IEnumerable<TReturn> Query<TFirst, TSecond, TReturn>(this IDapperSqlCommand command, Func<TFirst, TSecond, TReturn> map, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
+        public static IEnumerable<TReturn> Query<TFirst, TSecond, TReturn>(this IDapperSqlCommand command, Func<TFirst, TSecond, TReturn> map, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
         {
             return command.DbConnection.Query<TFirst, TSecond, TReturn>(sql: command.Sql, map: map, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, buffered: buffered, splitOn: splitOn);
         }
@@ -383,6 +391,7 @@ namespace InterpolatedSql.Dapper
         /// <typeparam name="TSecond">The second type in the recordset.</typeparam>
         /// <typeparam name="TThird">The third type in the recordset.</typeparam>
         /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="command">IDapperSqlCommand used to query the DbConnection.</param>
         /// <param name="map">The function to map row types to the return type.</param>
         /// <param name="transaction">The transaction to use for this query.</param>
         /// <param name="buffered">Whether to buffer the results in memory.</param>
@@ -390,7 +399,7 @@ namespace InterpolatedSql.Dapper
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static IEnumerable<TReturn> Query<TFirst, TSecond, TThird, TReturn>(this IDapperSqlCommand command, Func<TFirst, TSecond, TThird, TReturn> map, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
+        public static IEnumerable<TReturn> Query<TFirst, TSecond, TThird, TReturn>(this IDapperSqlCommand command, Func<TFirst, TSecond, TThird, TReturn> map, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
         {
             return command.DbConnection.Query<TFirst, TSecond, TThird, TReturn>(sql: command.Sql, map: map, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, buffered: buffered, splitOn: splitOn);
         }
@@ -404,6 +413,7 @@ namespace InterpolatedSql.Dapper
         /// <typeparam name="TThird">The third type in the recordset.</typeparam>
         /// <typeparam name="TFourth">The fourth type in the recordset.</typeparam>
         /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="command">IDapperSqlCommand used to query the DbConnection.</param>
         /// <param name="map">The function to map row types to the return type.</param>
         /// <param name="transaction">The transaction to use for this query.</param>
         /// <param name="buffered">Whether to buffer the results in memory.</param>
@@ -411,7 +421,7 @@ namespace InterpolatedSql.Dapper
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static IEnumerable<TReturn> Query<TFirst, TSecond, TThird, TFourth, TReturn>(this IDapperSqlCommand command, Func<TFirst, TSecond, TThird, TFourth, TReturn> map, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
+        public static IEnumerable<TReturn> Query<TFirst, TSecond, TThird, TFourth, TReturn>(this IDapperSqlCommand command, Func<TFirst, TSecond, TThird, TFourth, TReturn> map, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
         {
             return command.DbConnection.Query<TFirst, TSecond, TThird, TFourth, TReturn>(sql: command.Sql, map: map, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, buffered: buffered, splitOn: splitOn);
         }
@@ -426,6 +436,7 @@ namespace InterpolatedSql.Dapper
         /// <typeparam name="TFourth">The fourth type in the recordset.</typeparam>
         /// <typeparam name="TFifth">The fifth type in the recordset.</typeparam>
         /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="command">IDapperSqlCommand used to query the DbConnection.</param>
         /// <param name="map">The function to map row types to the return type.</param>
         /// <param name="transaction">The transaction to use for this query.</param>
         /// <param name="buffered">Whether to buffer the results in memory.</param>
@@ -433,7 +444,7 @@ namespace InterpolatedSql.Dapper
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static IEnumerable<TReturn> Query<TFirst, TSecond, TThird, TFourth, TFifth, TReturn>(this IDapperSqlCommand command, Func<TFirst, TSecond, TThird, TFourth, TFifth, TReturn> map, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
+        public static IEnumerable<TReturn> Query<TFirst, TSecond, TThird, TFourth, TFifth, TReturn>(this IDapperSqlCommand command, Func<TFirst, TSecond, TThird, TFourth, TFifth, TReturn> map, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
         {
             return command.DbConnection.Query<TFirst, TSecond, TThird, TFourth, TFifth, TReturn>(sql: command.Sql, map: map, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, buffered: buffered, splitOn: splitOn);
         }
@@ -449,6 +460,7 @@ namespace InterpolatedSql.Dapper
         /// <typeparam name="TFifth">The fifth type in the recordset.</typeparam>
         /// <typeparam name="TSixth">The sixth type in the recordset.</typeparam>
         /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="command">IDapperSqlCommand used to query the DbConnection.</param>
         /// <param name="map">The function to map row types to the return type.</param>
         /// <param name="transaction">The transaction to use for this query.</param>
         /// <param name="buffered">Whether to buffer the results in memory.</param>
@@ -456,7 +468,7 @@ namespace InterpolatedSql.Dapper
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static IEnumerable<TReturn> Query<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn>(this IDapperSqlCommand command, Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn> map, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
+        public static IEnumerable<TReturn> Query<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn>(this IDapperSqlCommand command, Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn> map, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
         {
             return command.DbConnection.Query<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn>(sql: command.Sql, map: map, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, buffered: buffered, splitOn: splitOn);
         }
@@ -473,6 +485,7 @@ namespace InterpolatedSql.Dapper
         /// <typeparam name="TSixth">The sixth type in the recordset.</typeparam>
         /// <typeparam name="TSeventh">The seventh type in the recordset.</typeparam>
         /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="command">IDapperSqlCommand used to query the DbConnection.</param>
         /// <param name="map">The function to map row types to the return type.</param>
         /// <param name="transaction">The transaction to use for this query.</param>
         /// <param name="buffered">Whether to buffer the results in memory.</param>
@@ -480,7 +493,7 @@ namespace InterpolatedSql.Dapper
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static IEnumerable<TReturn> Query<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(this IDapperSqlCommand command, Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn> map, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
+        public static IEnumerable<TReturn> Query<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(this IDapperSqlCommand command, Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn> map, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
         {
             return command.DbConnection.Query<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(sql: command.Sql, map: map, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, buffered: buffered, splitOn: splitOn);
         }
@@ -490,6 +503,7 @@ namespace InterpolatedSql.Dapper
         /// This returns a single type, combined from the raw types via <paramref name="map"/>.
         /// </summary>
         /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="command">IDapperSqlCommand used to query the DbConnection.</param>
         /// <param name="types">Array of types in the recordset.</param>
         /// <param name="map">The function to map row types to the return type.</param>
         /// <param name="transaction">The transaction to use for this query.</param>
@@ -498,7 +512,7 @@ namespace InterpolatedSql.Dapper
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static IEnumerable<TReturn> Query<TReturn>(this IDapperSqlCommand command, Type[] types, Func<object[], TReturn> map, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
+        public static IEnumerable<TReturn> Query<TReturn>(this IDapperSqlCommand command, Type[] types, Func<object[], TReturn> map, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
         {
             return command.DbConnection.Query<TReturn>(sql: command.Sql, types, map: map, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, buffered: buffered, splitOn: splitOn);
         }
@@ -513,18 +527,19 @@ namespace InterpolatedSql.Dapper
         /// <typeparam name="TFirst">The first type in the recordset.</typeparam>
         /// <typeparam name="TSecond">The second type in the recordset.</typeparam>
         /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="command">IDapperSqlCommand used to query the DbConnection.</param>
         /// <param name="map">The function to map row types to the return type.</param>
         /// <param name="transaction">The transaction to use for this query.</param>
         /// <param name="buffered">Whether to buffer the results in memory.</param>
         /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
+        /// <param name="cancellationToken">The cancellation token for this command.</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TReturn>(this IDapperSqlCommand command, Func<TFirst, TSecond, TReturn> map, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TReturn>(this IDapperSqlCommand command, Func<TFirst, TSecond, TReturn> map, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
-            return command.DbConnection.QueryAsync<TFirst, TSecond, TReturn>(sql: command.Sql, map: map, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, buffered: buffered, splitOn: splitOn);
+            return command.DbConnection.QueryAsync<TFirst, TSecond, TReturn>(command: new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, flags: buffered ? CommandFlags.Buffered : CommandFlags.None, cancellationToken: cancellationToken), map: map, splitOn: splitOn);
         }
-
 
         /// <summary>
         /// Perform a multi-mapping query with 3 input types.
@@ -534,16 +549,18 @@ namespace InterpolatedSql.Dapper
         /// <typeparam name="TSecond">The second type in the recordset.</typeparam>
         /// <typeparam name="TThird">The third type in the recordset.</typeparam>
         /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="command">IDapperSqlCommand used to query the DbConnection.</param>
         /// <param name="map">The function to map row types to the return type.</param>
         /// <param name="transaction">The transaction to use for this query.</param>
         /// <param name="buffered">Whether to buffer the results in memory.</param>
         /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
+        /// <param name="cancellationToken">The cancellation token for this command.</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TReturn>(this IDapperSqlCommand command, Func<TFirst, TSecond, TThird, TReturn> map, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TReturn>(this IDapperSqlCommand command, Func<TFirst, TSecond, TThird, TReturn> map, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
-            return command.DbConnection.QueryAsync<TFirst, TSecond, TThird, TReturn>(sql: command.Sql, map: map, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, buffered: buffered, splitOn: splitOn);
+            return command.DbConnection.QueryAsync<TFirst, TSecond, TThird, TReturn>(command: new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, flags: buffered ? CommandFlags.Buffered : CommandFlags.None, cancellationToken: cancellationToken), map: map, splitOn: splitOn);
         }
 
         /// <summary>
@@ -555,16 +572,18 @@ namespace InterpolatedSql.Dapper
         /// <typeparam name="TThird">The third type in the recordset.</typeparam>
         /// <typeparam name="TFourth">The fourth type in the recordset.</typeparam>
         /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="command">IDapperSqlCommand used to query the DbConnection.</param>
         /// <param name="map">The function to map row types to the return type.</param>
         /// <param name="transaction">The transaction to use for this query.</param>
         /// <param name="buffered">Whether to buffer the results in memory.</param>
         /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
+        /// <param name="cancellationToken">The cancellation token for this command.</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TFourth, TReturn>(this IDapperSqlCommand command, Func<TFirst, TSecond, TThird, TFourth, TReturn> map, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TFourth, TReturn>(this IDapperSqlCommand command, Func<TFirst, TSecond, TThird, TFourth, TReturn> map, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
-            return command.DbConnection.QueryAsync<TFirst, TSecond, TThird, TFourth, TReturn>(sql: command.Sql, map: map, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, buffered: buffered, splitOn: splitOn);
+            return command.DbConnection.QueryAsync<TFirst, TSecond, TThird, TFourth, TReturn>(command: new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, flags: buffered ? CommandFlags.Buffered : CommandFlags.None, cancellationToken: cancellationToken), map: map, splitOn: splitOn);
         }
 
         /// <summary>
@@ -577,16 +596,18 @@ namespace InterpolatedSql.Dapper
         /// <typeparam name="TFourth">The fourth type in the recordset.</typeparam>
         /// <typeparam name="TFifth">The fifth type in the recordset.</typeparam>
         /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="command">IDapperSqlCommand used to query the DbConnection.</param>
         /// <param name="map">The function to map row types to the return type.</param>
         /// <param name="transaction">The transaction to use for this query.</param>
         /// <param name="buffered">Whether to buffer the results in memory.</param>
         /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
+        /// <param name="cancellationToken">The cancellation token for this command.</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TReturn>(this IDapperSqlCommand command, Func<TFirst, TSecond, TThird, TFourth, TFifth, TReturn> map, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TReturn>(this IDapperSqlCommand command, Func<TFirst, TSecond, TThird, TFourth, TFifth, TReturn> map, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
-            return command.DbConnection.QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TReturn>(sql: command.Sql, map: map, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, buffered: buffered, splitOn: splitOn);
+            return command.DbConnection.QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TReturn>(command: new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, flags: buffered ? CommandFlags.Buffered : CommandFlags.None, cancellationToken: cancellationToken), map: map, splitOn: splitOn);
         }
 
         /// <summary>
@@ -600,16 +621,18 @@ namespace InterpolatedSql.Dapper
         /// <typeparam name="TFifth">The fifth type in the recordset.</typeparam>
         /// <typeparam name="TSixth">The sixth type in the recordset.</typeparam>
         /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="command">IDapperSqlCommand used to query the DbConnection.</param>
         /// <param name="map">The function to map row types to the return type.</param>
         /// <param name="transaction">The transaction to use for this query.</param>
         /// <param name="buffered">Whether to buffer the results in memory.</param>
         /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
+        /// <param name="cancellationToken">The cancellation token for this command.</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn>(this IDapperSqlCommand command, Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn> map, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn>(this IDapperSqlCommand command, Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn> map, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
-            return command.DbConnection.QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn>(sql: command.Sql, map: map, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, buffered: buffered, splitOn: splitOn);
+            return command.DbConnection.QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TReturn>(command: new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, flags: buffered ? CommandFlags.Buffered : CommandFlags.None, cancellationToken: cancellationToken), map: map, splitOn: splitOn);
         }
 
         /// <summary>
@@ -624,16 +647,18 @@ namespace InterpolatedSql.Dapper
         /// <typeparam name="TSixth">The sixth type in the recordset.</typeparam>
         /// <typeparam name="TSeventh">The seventh type in the recordset.</typeparam>
         /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="command">IDapperSqlCommand used to query the DbConnection.</param>
         /// <param name="map">The function to map row types to the return type.</param>
         /// <param name="transaction">The transaction to use for this query.</param>
         /// <param name="buffered">Whether to buffer the results in memory.</param>
         /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
+        /// <param name="cancellationToken">The cancellation token for this command.</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(this IDapperSqlCommand command, Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn> map, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<IEnumerable<TReturn>> QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(this IDapperSqlCommand command, Func<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn> map, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
-            return command.DbConnection.QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(sql: command.Sql, map: map, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, buffered: buffered, splitOn: splitOn);
+            return command.DbConnection.QueryAsync<TFirst, TSecond, TThird, TFourth, TFifth, TSixth, TSeventh, TReturn>(command: new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, flags: buffered ? CommandFlags.Buffered : CommandFlags.None, cancellationToken: cancellationToken), map: map, splitOn: splitOn);
         }
 
         /// <summary>
@@ -641,6 +666,7 @@ namespace InterpolatedSql.Dapper
         /// This returns a single type, combined from the raw types via <paramref name="map"/>.
         /// </summary>
         /// <typeparam name="TReturn">The combined type to return.</typeparam>
+        /// <param name="command">IDapperSqlCommand used to query the DbConnection.</param>
         /// <param name="types">Array of types in the recordset.</param>
         /// <param name="map">The function to map row types to the return type.</param>
         /// <param name="transaction">The transaction to use for this query.</param>
@@ -648,14 +674,13 @@ namespace InterpolatedSql.Dapper
         /// <param name="splitOn">The field we should split and read the second object from (default: "Id").</param>
         /// <param name="commandTimeout">Number of seconds before command execution timeout.</param>
         /// <param name="commandType">Is it a stored proc or a batch?</param>
+        /// <param name="cancellationToken">The cancellation token for this command.</param>
         /// <returns>An enumerable of <typeparamref name="TReturn"/>.</returns>
-        public static Task<IEnumerable<TReturn>> QueryAsync<TReturn>(this IDapperSqlCommand command, Type[] types, Func<object[], TReturn> map, IDbTransaction transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null)
+        public static Task<IEnumerable<TReturn>> QueryAsync<TReturn>(this IDapperSqlCommand command, Type[] types, Func<object[], TReturn> map, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
         {
-            return command.DbConnection.QueryAsync<TReturn>(sql: command.Sql, types, map: map, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, buffered: buffered, splitOn: splitOn);
+            return command.DbConnection.QueryAsync<TReturn>(sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, buffered: buffered, types: types, map: map, splitOn: splitOn);
+            // return command.DbConnection.QueryAsync<TReturn>(command: new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, flags: buffered ? CommandFlags.Buffered : CommandFlags.None, cancellationToken: cancellationToken), types: types, map: map, splitOn: splitOn);
         }
-
         #endregion
-
-
     }
 }


### PR DESCRIPTION
Added `CancellationToken` support.  I tagged you in a couple of tweets to Marc Gravell that you probably saw.  From what I understand, adding the optional `CancellationToken` parameter shouldn't break any existing compatibility, but maybe you know as well.  Maintaining open source compatibility is a new realm for me :)

Additionally, I submitted a [pr](https://github.com/DapperLib/Dapper/pull/2052) to Dapper to enable support on the following overload (currently, I just disregard the `CancellationToken`):

```
        public static Task<IEnumerable<TReturn>> QueryAsync<TReturn>(this IDapperSqlCommand command, Type[] types, Func<object[], TReturn> map, IDbTransaction? transaction = null, bool buffered = true, string splitOn = "Id", int? commandTimeout = null, CommandType? commandType = null, CancellationToken cancellationToken = default)
        {
            return command.DbConnection.QueryAsync<TReturn>(sql: command.Sql, param: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, buffered: buffered, types: types, map: map, splitOn: splitOn);
            // return command.DbConnection.QueryAsync<TReturn>(command: new CommandDefinition(commandText: command.Sql, parameters: ParametersDictionary.LoadFrom(command), transaction: transaction, commandTimeout: commandTimeout, commandType: commandType, flags: buffered ? CommandFlags.Buffered : CommandFlags.None, cancellationToken: cancellationToken), types: types, map: map, splitOn: splitOn);
        }
```