### PR TITLE
Properly pass options when using the SqlBuilder() and SqlBuilder<B>() extension methods on IDbConnection

### DIFF
--- a/src/InterpolatedSql.Dapper.Tests/InterpolatedSql.Dapper.Tests.csproj
+++ b/src/InterpolatedSql.Dapper.Tests/InterpolatedSql.Dapper.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netframework461;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net462;net5.0;net6.0;net7.0</TargetFrameworks>
 	<Nullable>enable</Nullable>
 
 	  <IsPackable>false</IsPackable>
@@ -26,6 +26,7 @@
     <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
   </ItemGroup>
 

--- a/src/InterpolatedSql.Dapper.Tests/InterpolatedSqlBuilderOptionsTests.cs
+++ b/src/InterpolatedSql.Dapper.Tests/InterpolatedSqlBuilderOptionsTests.cs
@@ -1,0 +1,17 @@
+using NUnit.Framework;
+using InterpolatedSql.SqlBuilders;
+using System.Data.SqlClient;
+
+namespace InterpolatedSql.Dapper.Tests;
+
+public class InterpolatedSqlBuilderOptionsTests
+{
+    [Test]
+    public void SqlBuilderWithOptions()
+    {
+        var cn = new SqlConnection();
+        var qb = cn.SqlBuilder(new InterpolatedSqlBuilderOptions { DatabaseParameterSymbol = ":" }, $"{"A"} {1}");
+        var sql = qb.Build().Sql;
+        Assert.AreEqual(":p0 :p1", sql);
+    }
+}

--- a/src/InterpolatedSql.Dapper.Tests/InterpolatedSqlBuilderOptionsTests.cs
+++ b/src/InterpolatedSql.Dapper.Tests/InterpolatedSqlBuilderOptionsTests.cs
@@ -14,4 +14,13 @@ public class InterpolatedSqlBuilderOptionsTests
         var sql = qb.Build().Sql;
         Assert.AreEqual(":p0 :p1", sql);
     }
+
+    [Test]
+    public void QueryBuilderWithOptions()
+    {
+        var cn = new SqlConnection();
+        var qb = cn.SqlBuilder<InterpolatedSql.Dapper.SqlBuilders.QueryBuilder>(new InterpolatedSqlBuilderOptions { DatabaseParameterSymbol = ":" }, $"{"A"} {1}");
+        var sql = qb.Build().Sql;
+        Assert.AreEqual(":p0 :p1", sql);
+    }
 }

--- a/src/InterpolatedSql.Dapper/IDbConnectionExtensions.cs
+++ b/src/InterpolatedSql.Dapper/IDbConnectionExtensions.cs
@@ -68,7 +68,7 @@ namespace InterpolatedSql.Dapper
         {
             if (command.InterpolatedSqlBuilder.Options.AutoAdjustMultilineString)
                 command.AdjustMultilineString();
-            return new SqlBuilder(cnn, command.InterpolatedSqlBuilder.AsFormattableString());
+            return new SqlBuilder(cnn, command.InterpolatedSqlBuilder.AsFormattableString(), options);
         }
 
 #else

--- a/src/InterpolatedSql.Dapper/IDbConnectionExtensions.cs
+++ b/src/InterpolatedSql.Dapper/IDbConnectionExtensions.cs
@@ -57,7 +57,7 @@ namespace InterpolatedSql.Dapper
         {
             if (command.InterpolatedSqlBuilder.Options.AutoAdjustMultilineString)
                 command.AdjustMultilineString();
-            return SqlBuilderFactory.Create<B>(cnn, command.InterpolatedSqlBuilder.AsFormattableString());
+            return SqlBuilderFactory.Create<B>(cnn, command.InterpolatedSqlBuilder.AsFormattableString(), options);
         }
 
         /// <summary>

--- a/src/InterpolatedSql.Dapper/SqlBuilderFactory.cs
+++ b/src/InterpolatedSql.Dapper/SqlBuilderFactory.cs
@@ -48,7 +48,8 @@ namespace InterpolatedSql.Dapper
         public virtual B Create<B>(IDbConnection connection, FormattableString command)
             where B : IDapperSqlBuilder
         {
-            var ctor = typeof(B).GetConstructor(new Type[] { typeof(IDbConnection), typeof(FormattableString) })!;
+            var ctor = typeof(B).GetConstructor(new Type[] { typeof(IDbConnection), typeof(FormattableString) })
+                       ?? throw new MissingMemberException(typeof(B).FullName, ".ctor(IDbConnection, FormattableString)");
             B builder = (B)ctor.Invoke(new object[] { connection, command });
             return builder;
         }
@@ -59,7 +60,8 @@ namespace InterpolatedSql.Dapper
         public virtual B Create<B>(IDbConnection connection, FormattableString command, InterpolatedSqlBuilderOptions? options = null)
             where B : IDapperSqlBuilder
         {
-            var ctor = typeof(B).GetConstructor(new Type[] { typeof(IDbConnection), typeof(FormattableString), typeof(InterpolatedSqlBuilderOptions) })!;
+            var ctor = typeof(B).GetConstructor(new Type[] { typeof(IDbConnection), typeof(FormattableString), typeof(InterpolatedSqlBuilderOptions) })
+                       ?? throw new MissingMemberException(typeof(B).FullName, ".ctor(IDbConnection, FormattableString, InterpolatedSqlBuilderOptions)");
             B builder = (B)ctor.Invoke(new object[] { connection, command, options! });
             return builder;
         }
@@ -71,7 +73,8 @@ namespace InterpolatedSql.Dapper
         public virtual B Create<B>(IDbConnection connection, int literalLength, int formattedCount)
             where B : IDapperSqlBuilder
         {
-            var ctor = typeof(B).GetConstructor(new Type[] { typeof(IDbConnection), typeof(int), typeof(int) })!;
+            var ctor = typeof(B).GetConstructor(new Type[] { typeof(IDbConnection), typeof(int), typeof(int) })
+                       ?? throw new MissingMemberException(typeof(B).FullName, ".ctor(IDbConnection, int, int)");
             B builder = (B)ctor.Invoke(new object[] { connection, literalLength, formattedCount });
             return builder;
         }
@@ -82,7 +85,8 @@ namespace InterpolatedSql.Dapper
         public virtual B Create<B>(IDbConnection connection, int literalLength, int formattedCount, InterpolatedSqlBuilderOptions? options = null)
             where B : IDapperSqlBuilder
         {
-            var ctor = typeof(B).GetConstructor(new Type[] { typeof(IDbConnection), typeof(int), typeof(int), typeof(InterpolatedSqlBuilderOptions) })!;
+            var ctor = typeof(B).GetConstructor(new Type[] { typeof(IDbConnection), typeof(int), typeof(int), typeof(InterpolatedSqlBuilderOptions) })
+                       ?? throw new MissingMemberException(typeof(B).FullName, ".ctor(IDbConnection, int, int, InterpolatedSqlBuilderOptions)");
             B builder = (B)ctor.Invoke(new object?[] { connection, literalLength, formattedCount, options });
             return builder;
         }

--- a/src/InterpolatedSql.Dapper/SqlBuilders/QueryBuilder/QueryBuilder.cs
+++ b/src/InterpolatedSql.Dapper/SqlBuilders/QueryBuilder/QueryBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using InterpolatedSql.SqlBuilders;
+using System;
 using System.Data;
 
 namespace InterpolatedSql.Dapper.SqlBuilders
@@ -14,6 +15,11 @@ namespace InterpolatedSql.Dapper.SqlBuilders
 
         /// <inheritdoc/>
         public QueryBuilder(IDbConnection connection, FormattableString query) : base(opts => new SqlBuilder(connection, opts), (opts, format, arguments) => new SqlBuilder(connection, opts, format, arguments), connection, query)
+        {
+        }
+
+        /// <inheritdoc/>
+        public QueryBuilder(IDbConnection connection, FormattableString query, InterpolatedSqlBuilderOptions? options = null) : base(_ => new SqlBuilder(connection, options), (_, format, arguments) => new SqlBuilder(connection, options, format, arguments), connection, query)
         {
         }
         #endregion

--- a/src/InterpolatedSql.Tests/InterpolatedSql.Tests.csproj
+++ b/src/InterpolatedSql.Tests/InterpolatedSql.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netframework461;net5.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>net462;net5.0;net6.0</TargetFrameworks>
 		<IsPackable>false</IsPackable>
 		<Company>Rick Drizin</Company>
 		<Copyright>Rick Drizin</Copyright>


### PR DESCRIPTION
Before, the options were not passed to the SqlBuilder, so they were simply ignored.

After this pull request, the options are properly passed to the SqlBuilder.

New tests were added with a non-default `DatabaseParameterSymbol` (`:`) to ensure that the options are properly passed down the line.

Also, the test projects needed some tweaks to compile.