### PR TITLE
make ctor protected only

### DIFF
--- a/src/InterpolatedSql.Dapper/SqlBuilders/SqlBuilder/SqlBuilder.cs
+++ b/src/InterpolatedSql.Dapper/SqlBuilders/SqlBuilder/SqlBuilder.cs
@@ -11,7 +11,7 @@ namespace InterpolatedSql.Dapper.SqlBuilders
     {
         #region ctors
         /// <inheritdoc />
-        protected internal SqlBuilder(IDbConnection connection, InterpolatedSqlBuilderOptions? options, StringBuilder? format, List<InterpolatedSqlParameter>? arguments) : base(connection, options, format, arguments)
+        protected SqlBuilder(IDbConnection connection, InterpolatedSqlBuilderOptions? options, StringBuilder? format, List<InterpolatedSqlParameter>? arguments) : base(connection, options, format, arguments)
         {
             DbConnection = connection;
         }


### PR DESCRIPTION
This allows calling the ctor when extending the InterpolatedSql.Dapper.SqlBuilders.QueryBuilder<U, RB, R> more easily without having to use reflection
This pull request makes a minor change to the `SqlBuilder` class in the `src/InterpolatedSql.Dapper/SqlBuilders/SqlBuilder/SqlBuilder.cs` file. The change modifies the constructor's accessibility level from `protected internal` to `protected`. 